### PR TITLE
remove graph config from publish.js

### DIFF
--- a/end-to-end/packages/hardhat/scripts/publish.js
+++ b/end-to-end/packages/hardhat/scripts/publish.js
@@ -20,22 +20,7 @@ function publishContract(contractName) {
       .readFileSync(`${bre.config.paths.artifacts}/${contractName}.address`)
       .toString();
     contract = JSON.parse(contract);
-    let graphConfigPath = `${graphDir}/config/config.json`
-    let graphConfig
-    try {
-      if (fs.existsSync(graphConfigPath)) {
-        graphConfig = fs
-          .readFileSync(graphConfigPath)
-          .toString();
-      } else {
-        graphConfig = '{}'
-      }
-      } catch (e) {
-        console.log(e)
-      }
 
-    graphConfig = JSON.parse(graphConfig)
-    graphConfig[contractName + "Address"] = address
     fs.writeFileSync(
       `${publishDir}/${contractName}.address.js`,
       `module.exports = "${address}";`
@@ -47,19 +32,6 @@ function publishContract(contractName) {
     fs.writeFileSync(
       `${publishDir}/${contractName}.bytecode.js`,
       `module.exports = "${contract.bytecode}";`
-    );
-
-    const folderPath = graphConfigPath.replace("/config.json","")
-    if (!fs.existsSync(folderPath)){
-      fs.mkdirSync(folderPath);
-    }
-    fs.writeFileSync(
-      graphConfigPath,
-      JSON.stringify(graphConfig, null, 2)
-    );
-    fs.writeFileSync(
-      `${graphDir}/abis/${contractName}.json`,
-      JSON.stringify(contract.abi, null, 2)
     );
 
     console.log(" 📠 Published "+chalk.green(contractName)+" to the frontend.")


### PR DESCRIPTION
I think that [the Connecting... bug](https://github.com/protocol/nft-website/issues/85) is happening because of a failure in the publish script - it can't find something related to The Graph, and then it bails out before writing the contract address to the frontend config.

Since we're not using The Graph in this example, I just removed all the graph stuff from the publish script. Now on a fresh clone I can follow the example and connect to the contract.