### PR TITLE
fix: use on-chain value of chain id when signing nft vouchers

### DIFF
--- a/lazy-minting/contracts/LazyNFT.sol
+++ b/lazy-minting/contracts/LazyNFT.sol
@@ -93,6 +93,17 @@ contract LazyNFT is ERC721URIStorage, EIP712, AccessControl {
     )));
   }
 
+  /// @notice Returns the chain id of the current blockchain.
+  /// @dev This is used to workaround an issue with ganache returning different values from the on-chain chainid() function and
+  ///  the eth_chainId RPC method. See https://github.com/protocol/nft-website/issues/121 for context.
+  function getChainID() external view returns (uint256) {
+    uint256 id;
+    assembly {
+        id := chainid()
+    }
+    return id;
+  }
+
   /// @notice Verifies the signature for a given NFTVoucher, returning the address of the signer.
   /// @dev Will revert if the signature is invalid. Does not verify that the signer is authorized to mint NFTs.
   /// @param voucher An NFTVoucher describing an unminted NFT.

--- a/lazy-minting/hardhat.config.js
+++ b/lazy-minting/hardhat.config.js
@@ -18,5 +18,16 @@ task("accounts", "Prints the list of accounts", async () => {
  */
 module.exports = {
   solidity: "0.8.4",
+  defaultNetwork: "hardhat",
+  networks: {
+    hardhat: {},
+    ganache: {
+      url: "http://127.0.0.1:7545",
+      accounts: {
+        mnemonic: "symptom bean awful husband dice accident crush tank sun notice club creek",
+      },
+      // chainId: 1234,
+    }
+  }
 };
 

--- a/lazy-minting/lib/LazyMinter.js
+++ b/lazy-minting/lib/LazyMinter.js
@@ -23,11 +23,11 @@ class LazyMinter {
    * Create a new LazyMinter targeting a deployed instance of the LazyNFT contract.
    * 
    * @param {Object} options
-   * @param {string} contractAddress the address of the deployed LazyNFT contract
+   * @param {ethers.Contract} contract an ethers Contract that's wired up to the deployed contract
    * @param {ethers.Signer} signer a Signer whose account is authorized to mint NFTs on the deployed contract
    */
-  constructor({ contractAddress, signer }) {
-    this.contractAddress = contractAddress
+  constructor({ contract, signer }) {
+    this.contract = contract
     this.signer = signer
   }
 
@@ -65,11 +65,11 @@ class LazyMinter {
     if (this._domain != null) {
       return this._domain
     }
-    const chainId = await this.signer.getChainId()
+    const chainId = await this.contract.getChainID()
     this._domain = {
       name: SIGNING_DOMAIN_NAME,
       version: SIGNING_DOMAIN_VERSION,
-      verifyingContract: this.contractAddress,
+      verifyingContract: this.contract.address,
       chainId,
     }
     return this._domain

--- a/lazy-minting/package-lock.json
+++ b/lazy-minting/package-lock.json
@@ -16711,7 +16711,9 @@
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-2.0.0.tgz",
       "integrity": "sha512-0xdCkyGOzdqh4h5JSf+zoWx85IusEjDcPIwNEHP8mrWSnCae4rvrqB+/gtpdNfX7zjlFlZiMeePn2r63EI3Lrw==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "ethers": "^5.0.2"
+      }
     },
     "@types/abstract-leveldown": {
       "version": "5.0.1",

--- a/lazy-minting/test/lazy-test.js
+++ b/lazy-minting/test/lazy-test.js
@@ -1,5 +1,6 @@
 const { expect } = require("chai");
-const { ethers } = require("hardhat");
+const hardhat = require("hardhat");
+const { ethers } = hardhat;
 const { LazyMinter } = require('../lib')
 
 async function deploy() {
@@ -28,13 +29,12 @@ describe("LazyNFT", function() {
     const LazyNFT = await ethers.getContractFactory("LazyNFT");
     const lazynft = await LazyNFT.deploy(minter);
     await lazynft.deployed();
-
   });
 
   it("Should redeem an NFT from a signed voucher", async function() {
     const { contract, redeemerContract, redeemer, minter } = await deploy()
 
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: minter })
+    const lazyMinter = new LazyMinter({ contract, signer: minter })
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 
     await expect(redeemerContract.redeem(redeemer.address, voucher))
@@ -47,7 +47,7 @@ describe("LazyNFT", function() {
   it("Should fail to redeem an NFT that's already been claimed", async function() {
     const { contract, redeemerContract, redeemer, minter } = await deploy()
 
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: minter })
+    const lazyMinter = new LazyMinter({ contract, signer: minter })
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 
     await expect(redeemerContract.redeem(redeemer.address, voucher))
@@ -66,7 +66,7 @@ describe("LazyNFT", function() {
     const signers = await ethers.getSigners()
     const rando = signers[signers.length-1];
     
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: rando })
+    const lazyMinter = new LazyMinter({ contract, signer: rando })
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 
     await expect(redeemerContract.redeem(redeemer.address, voucher))
@@ -79,7 +79,7 @@ describe("LazyNFT", function() {
     const signers = await ethers.getSigners()
     const rando = signers[signers.length-1];
     
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: rando })
+    const lazyMinter = new LazyMinter({ contract, signer: rando })
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
     voucher.tokenId = 2
     await expect(redeemerContract.redeem(redeemer.address, voucher))
@@ -92,7 +92,7 @@ describe("LazyNFT", function() {
     const signers = await ethers.getSigners()
     const rando = signers[signers.length-1];
     
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: rando })
+    const lazyMinter = new LazyMinter({ contract, signer: rando })
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi")
 
     const dummyData = ethers.utils.randomBytes(128)
@@ -105,7 +105,7 @@ describe("LazyNFT", function() {
   it("Should redeem if payment is >= minPrice", async function() {
     const { contract, redeemerContract, redeemer, minter } = await deploy()
 
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: minter })
+    const lazyMinter = new LazyMinter({ contract, signer: minter })
     const minPrice = ethers.constants.WeiPerEther // charge 1 Eth
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi", minPrice)
 
@@ -119,7 +119,7 @@ describe("LazyNFT", function() {
   it("Should fail to redeem if payment is < minPrice", async function() {
     const { contract, redeemerContract, redeemer, minter } = await deploy()
 
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: minter })
+    const lazyMinter = new LazyMinter({ contract, signer: minter })
     const minPrice = ethers.constants.WeiPerEther // charge 1 Eth
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi", minPrice)
 
@@ -131,7 +131,7 @@ describe("LazyNFT", function() {
   it("Should make payments available to minter for withdrawal", async function() {
     const { contract, redeemerContract, redeemer, minter } = await deploy()
 
-    const lazyMinter = new LazyMinter({ contractAddress: contract.address, signer: minter })
+    const lazyMinter = new LazyMinter({ contract, signer: minter })
     const minPrice = ethers.constants.WeiPerEther // charge 1 Eth
     const voucher = await lazyMinter.createVoucher(1, "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi", minPrice)
     


### PR DESCRIPTION
This adds a `getChainID` contract function and uses it in place of `signer.getChainId()` when signing vouchers for the lazy minting example, to fix an issue where signatures wouldn't validate when running on ganache.

Closes #4.